### PR TITLE
Expose `backup` module for `RocksDB`, fix naming register

### DIFF
--- a/matterdb/Cargo.toml
+++ b/matterdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matterdb"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2018"
 authors = ["Igor Aleksanov <popzxc@yandex.ru", "The Exonum Team <contact@exonum.com>"]
 repository = "https://github.com/popzxc/matterdb"

--- a/matterdb/benches/benchmarks/mod.rs
+++ b/matterdb/benches/benchmarks/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::upper_case_acronyms)]
 
-use matterdb::{Database, DbOptions, Fork, Patch, Result, RocksDB, Snapshot};
+use matterdb::{DBOptions, Database, Fork, Patch, Result, RocksDB, Snapshot};
 use tempfile::{tempdir, TempDir};
 
 pub mod encoding;
@@ -16,7 +16,7 @@ impl BenchDB {
     pub(crate) fn new() -> Self {
         let dir = tempdir().expect("Couldn't create tempdir");
         let db =
-            RocksDB::open(dir.path(), &DbOptions::default()).expect("Couldn't create database");
+            RocksDB::open(dir.path(), &DBOptions::default()).expect("Couldn't create database");
         Self { _dir: dir, db }
     }
 

--- a/matterdb/src/backends/temporarydb.rs
+++ b/matterdb/src/backends/temporarydb.rs
@@ -10,7 +10,7 @@ use std::{
 
 use crate::{
     backends::rocksdb::{next_id_bytes, ID_SIZE},
-    db::{check_database, Change, Iterator as DbIterator},
+    db::{check_database, Change, Iterator as DBIterator},
     Database, Iter, Patch, ResolvedAddress, Result, Snapshot,
 };
 
@@ -124,7 +124,7 @@ impl Database for TemporaryDB {
     }
 }
 
-impl<'a> DbIterator for TemporaryDBIterator<'a> {
+impl<'a> DBIterator for TemporaryDBIterator<'a> {
     fn next(&mut self) -> Option<(&[u8], &[u8])> {
         if self.ended {
             return None;

--- a/matterdb/src/lib.rs
+++ b/matterdb/src/lib.rs
@@ -118,7 +118,10 @@ pub mod _reexports {
 }
 
 pub use self::{
-    backends::{rocksdb::RocksDB, temporarydb::TemporaryDB},
+    backends::{
+        rocksdb::{self, RocksDB},
+        temporarydb::TemporaryDB,
+    },
     db::{
         Database, DatabaseExt, Fork, Iter, Iterator, OwnedReadonlyFork, Patch, ReadonlyFork,
         Snapshot,
@@ -126,7 +129,7 @@ pub use self::{
     error::Error,
     keys::BinaryKey,
     lazy::Lazy,
-    options::DbOptions,
+    options::DBOptions,
     values::BinaryValue,
     views::{AsReadonly, IndexAddress, IndexType, ResolvedAddress},
 };

--- a/matterdb/src/options.rs
+++ b/matterdb/src/options.rs
@@ -8,7 +8,7 @@ use serde_derive::{Deserialize, Serialize};
 /// These parameters apply to the underlying database, currently `RocksDB`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[non_exhaustive]
-pub struct DbOptions {
+pub struct DBOptions {
     /// Number of open files that can be used by the database.
     ///
     /// The underlying database opens multiple files during operation. If your system has a
@@ -39,8 +39,8 @@ pub struct DbOptions {
     pub max_total_wal_size: Option<u64>,
 }
 
-impl DbOptions {
-    /// Creates a new `DbOptions` object.
+impl DBOptions {
+    /// Creates a new `DBOptions` object.
     pub fn new(
         max_open_files: Option<i32>,
         create_if_missing: bool,
@@ -88,7 +88,7 @@ impl From<CompressionType> for DBCompressionType {
     }
 }
 
-impl Default for DbOptions {
+impl Default for DBOptions {
     fn default() -> Self {
         Self::new(None, true, CompressionType::None, None)
     }

--- a/matterdb/src/views/tests.rs
+++ b/matterdb/src/views/tests.rs
@@ -8,7 +8,7 @@ use crate::{
     db,
     validation::is_valid_identifier,
     views::{IndexAddress, IndexType, RawAccess, View, ViewWithMetadata},
-    Database, DbOptions, Fork, ListIndex, MapIndex, ResolvedAddress, RocksDB, TemporaryDB,
+    DBOptions, Database, Fork, ListIndex, MapIndex, ResolvedAddress, RocksDB, TemporaryDB,
 };
 
 const IDX_NAME: &str = "idx_name";
@@ -361,7 +361,7 @@ fn test_database_check_correct_version() {
 #[should_panic(expected = "actual 2, expected 0")]
 fn test_database_check_incorrect_version() {
     let dir = tempfile::TempDir::new().unwrap();
-    let opts = DbOptions::default();
+    let opts = DBOptions::default();
     // Writes different version to metadata.
     {
         let db = RocksDB::open(&dir, &opts).unwrap();

--- a/matterdb/tests/checkpoints.rs
+++ b/matterdb/tests/checkpoints.rs
@@ -1,4 +1,4 @@
-use matterdb::{access::CopyAccessExt, Database, DbOptions, RocksDB};
+use matterdb::{access::CopyAccessExt, DBOptions, Database, RocksDB};
 use tempfile::TempDir;
 
 #[test]
@@ -10,7 +10,7 @@ fn checkpoints() {
     let dst_path = dst_temp_dir.path().join("dst");
 
     // Convert into `dyn Database` to test downcast.
-    let db = RocksDB::open(&*src_path, &DbOptions::default()).unwrap();
+    let db = RocksDB::open(&*src_path, &DBOptions::default()).unwrap();
 
     // Write some data to the source database.
     {
@@ -37,7 +37,7 @@ fn checkpoints() {
     // Open checkpoint and Assert that it's not affected
     // by the data added after create_checkpoint call.
     {
-        let checkpoint = RocksDB::open(&*dst_path, &DbOptions::default()).unwrap();
+        let checkpoint = RocksDB::open(&*dst_path, &DBOptions::default()).unwrap();
         let fork = checkpoint.fork();
 
         assert_eq!(fork.get_entry("first").get(), Some(vec![1_u8; 1024]));
@@ -50,7 +50,7 @@ fn checkpoints() {
 
     // Assert that source database is not affected by the data added to checkpoint.
     {
-        let db = RocksDB::open(&*src_path, &DbOptions::default()).unwrap();
+        let db = RocksDB::open(&*src_path, &DBOptions::default()).unwrap();
         let fork = db.fork();
 
         assert_eq!(fork.get_entry("first").get(), Some(vec![1_u8; 1024]));
@@ -63,7 +63,7 @@ fn checkpoints() {
 
     // Assert that checkpoint is not affected if source database is deleted.
     {
-        let checkpoint = RocksDB::open(&*dst_path, &DbOptions::default()).unwrap();
+        let checkpoint = RocksDB::open(&*dst_path, &DBOptions::default()).unwrap();
         let fork = checkpoint.fork();
 
         assert_eq!(fork.get_entry("first").get(), Some(vec![1_u8; 1024]));


### PR DESCRIPTION
- Expose `backup` module for `RocksDB`
- Fix naming issue with different register (as `DB` variant is used in `RocksDB` and has most frequent occurrence in this crate, replace `Db` prefix with `DB`).